### PR TITLE
fix for #31 - change clashing related_name

### DIFF
--- a/pinax/comments/models.py
+++ b/pinax/comments/models.py
@@ -8,7 +8,7 @@ from django.db import models
 
 class Comment(models.Model):
 
-    author = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, related_name="comments", on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, related_name="pinax_comments", on_delete=models.CASCADE)
 
     name = models.CharField(max_length=100)
     email = models.CharField(max_length=255, blank=True)


### PR DESCRIPTION
Fix for  #31

This just renames the related_name that clashes with Wagtail `comments` related name.
I didn't find any reference of this related name in this project, so I suppose it is safe.

